### PR TITLE
Created a CI workflow for building wheels on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: CI Wheel building test
+
+on: 
+  pull_request:
+    branches: [main, develop]
+  push: 
+     branches: [main, develop, ci_build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up python  ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with: 
+          python-version: ${{ matrix.python-version }}
+      - name: Install ubuntu dependencies
+        run: |
+          sudo apt update
+          apt install build-essential cmake libhdf5-dev libtiff-dev
+      - name: Configure Cmake and build
+        run: | 
+          cmake  -D mcnptools.python_install=User .
+          cmake --build . --config Release
+      - name: Test C++ side
+        run: ctest --build-config Release
+      - name: build wheel
+        run: |
+          cd python
+          pip install build
+          python -m build .
+      - name: test install wheel
+        run: pip install dist/*.whl
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with: 
+           name: build
+           path: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-latest
+    runs-on: $${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: ["ubuntu-latest", "ubuntu-24.04-arm"]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +40,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with: 
-           name: wheel-linux-${{ matrix.python-version }}
+           name: wheel-linux-$${{ matrix.os }}-${{ matrix.python-version }}
            path: python/dist/*.whl
       - name: Upload Source tar bal
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
      branches: [main, develop, ci_build]
 
 jobs:
-  build:
+  build_linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,9 +35,9 @@ jobs:
           pip install build
           python -m build .
       - name: test install wheel
-        run: pip install dist/*.whl
+        run: pip install python/dist/*.whl
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with: 
-           name: build
-           path: dist/*
+           name: build-${{ matrix.python-version }}
+           path: python/dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,5 +39,11 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with: 
-           name: build-${{ matrix.python-version }}
-           path: python/dist/*
+           name: wheel-linux-${{ matrix.python-version }}
+           path: python/dist/*.whl
+      - name: Upload Source tar bal
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.python-version == '3.12'}}
+        with: 
+           name: linux_source
+           path: dist/*.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install ubuntu dependencies
         run: |
-          sudo apt update
-          apt install build-essential cmake libhdf5-dev libtiff-dev
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libhdf5-dev libtiff-dev
       - name: Configure Cmake and build
         run: | 
           cmake  -D mcnptools.python_install=User .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,4 +46,4 @@ jobs:
         if: ${{ matrix.python-version == '3.12'}}
         with: 
            name: linux_source
-           path: dist/*.gz
+           path: python/dist/*.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,40 @@
 *~
 *.bak
 *.sw?
+
+# cmake artifacts
+CMakeCache.txt
+CMakeFiles/
+CTestTestfile.cmake
+*.tcl
+Makefile
+*.cmake
+*.a
+*.so
+*.unix
+
+# testing artifacts
+Testing/
+git-submodule-packages/
+lib/
+libmcnptools/tests/
+*.vts
+
+
+# python build artifacts
+python/build
+python/dist
+python/setup.py
+python/setup.py_configure
+python/mcnptools.egg-info
+
+# Build executables
+libmcnptools/include/mcnptools/MCNPTools_Config.hpp
+utils/l3d2vtk/l3d2vtk
+utils/l3dcoarsen/l3dcoarsen
+utils/l3dinfo/l3dinfo
+utils/l3dscale/l3dscale
+utils/mctal2rad/mctal2rad
+utils/mergemctals/mergemctals
+utils/mergemeshtals/mergemeshtals
+utils/meshtal2vtk/meshtal2vtk


### PR DESCRIPTION
This is related to #9.

This workflow simply:

1. for all PRs and pushes to `main` runs this job
2. Goes through installation process
3. Creates a python wheel and source distribution for python 3.9 - 3.13
4. Uploads these are build artifacts.

These artifacts will be temporary (~1 month), and does not help with creating github releases. See [example here](https://github.com/MicahGale/mcnptools/actions/workflows/build.yml).

Help would still be needed for windows and mac. 


# Note:

Github actions would need to be enabled on this repository.